### PR TITLE
fix bug when ffmpeg is not installed

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,7 +124,7 @@ def check_ffmpeg():
             ["ffmpeg", "-version"], capture_output=True, check=True, text=True
         )
         return True
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
when I run it without ffmpeg, it [crashed with a FileNotFoundError](https://pastebin.com/qmeSMqf7) instead of CalledProcessError
(on windows)